### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/devopsincanada/f1426310-fb49-4fe4-a0f8-22a6ac296105/ee29d805-2d4b-476d-8e15-0f28856a1341/_apis/work/boardbadge/e4561b28-68dc-4ff6-91d9-b7a66be824d8)](https://dev.azure.com/devopsincanada/f1426310-fb49-4fe4-a0f8-22a6ac296105/_boards/board/t/ee29d805-2d4b-476d-8e15-0f28856a1341/Microsoft.RequirementCategory)
 | Language | Platform | Author |
 | -------- | --------|--------|
 | HTML |  Azure Web App, Virtual Machine| |


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#636](https://dev.azure.com/devopsincanada/f1426310-fb49-4fe4-a0f8-22a6ac296105/_workitems/edit/636). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.